### PR TITLE
Learn words on >= Windows 8

### DIFF
--- a/src/context-menu-builder.js
+++ b/src/context-menu-builder.js
@@ -1,5 +1,5 @@
 import {clipboard, nativeImage, remote, shell} from 'electron';
-import {truncateString} from './utility';
+import {truncateString, shouldUseHunspell} from './utility';
 
 const {Menu, MenuItem} = remote;
 
@@ -201,7 +201,7 @@ export default class ContextMenuBuilder {
 
     // Gate learning words based on OS support. At some point we can manage a
     // custom dictionary for Hunspell, but today is not that day
-    if (process.platform === 'darwin') {
+    if (!shouldUseHunspell()) {
       let learnWord = new MenuItem({
         label: `Add to Dictionary`,
         click: async () => {

--- a/src/dictionary-sync.js
+++ b/src/dictionary-sync.js
@@ -23,7 +23,7 @@ const {downloadFileOrUrl} =
 export default class DictionarySync {
   /**
    * Creates a DictionarySync
-   * 
+   *
    * @param  {String} cacheDir    The path to a directory to store dictionaries.
    *                              If not given, the Electron user data directory
    *                              will be used.
@@ -36,24 +36,24 @@ export default class DictionarySync {
   /**
    * Override the default logger for this class. You probably want to use
    * {{setGlobalLogger}} instead
-   * 
+   *
    * @param {Function} fn   The function which will operate like console.log
-   */  
+   */
   static setLogger(fn) {
     d = fn;
   }
 
   /**
-   * Loads the dictionary for a given language code, trying first to load a 
-   * local version, then downloading it. You probably don't want this method 
-   * directly, but the wrapped version 
+   * Loads the dictionary for a given language code, trying first to load a
+   * local version, then downloading it. You probably don't want this method
+   * directly, but the wrapped version
    * {{loadDictionaryForLanguageWithAlternatives}} which is in {{SpellCheckHandler}}.
-   * 
+   *
    * @param  {String} langCode        The language code (i.e. 'en-US')
    * @param  {Boolean} cacheOnly      If true, don't load the file content into
    *                                  memory, only download it
-   * 
-   * @return {Promise<Buffer|String>}     A Buffer of the file contents if 
+   *
+   * @return {Promise<Buffer|String>}     A Buffer of the file contents if
    *                                      {{cacheOnly}} is False, or the path to
    *                                      the file if True.
    */
@@ -70,12 +70,12 @@ export default class DictionarySync {
         fileExists = true;
         d(`Returning local copy: ${target}`);
         let ret = await fs.readFile(target, {});
-      
+
         if (ret.length < 8*1024) {
           throw new Error("File exists but is most likely bogus");
         }
 
-	return ret;
+        return ret;
       }
     } catch (e) {
       d(`Failed to read file ${target}: ${e.message}`);
@@ -105,14 +105,14 @@ export default class DictionarySync {
   }
 
   /**
-   * Pre-download dictionaries for languages that the user is likely to speak 
+   * Pre-download dictionaries for languages that the user is likely to speak
    * (based usually on their keyboard layouts). Note that this method only works
    * on Windows currently.
-   * 
+   *
    * @param  {Array<String>} languageList     Override the list of languages to
    *                                          download, for testing.
    *
-   * @return {Promise<Array<String>>}         A list of strings to dictionaries 
+   * @return {Promise<Array<String>>}         A list of strings to dictionaries
    *                                          that were downloaded.
    */
   preloadDictionaries(languageList=null) {

--- a/src/utility.js
+++ b/src/utility.js
@@ -1,3 +1,4 @@
+import os from 'os';
 
 /**
  * Normalizes language codes by case and separator. Unfortunately, different
@@ -32,4 +33,29 @@ export function truncateString(string) {
   let result = match[0].replace(/\s$/,'');
   if (length < string.length) result += "…";
   return result;
+}
+
+/**
+ * Returns true if we are using Hunspell and false if we are using system
+ * dictionaries.
+ *
+ * @return {Bool}   False if using the system dictionary
+ */
+export function shouldUseHunspell() {
+  if (process.platform === 'linux') return true;
+
+  if (process.platform === 'darwin') return false;
+
+  // For testing: used to ignore Win8 spellchecker even if it's available.
+  if (process.env.SPELLCHECKER_PREFER_HUNSPELL) return true;
+
+  let [major, minor] = os.release().split('.').map((part) => parseInt(part));
+
+  // Win10 or greater?
+  if (major > 6) return false;
+
+  // Win8 or greater? We use system dictionary API
+  if (major === 6 && minor >= 2) return false;
+
+  return true;
 }


### PR DESCRIPTION
If we're on Windows 8, 8.1, or 10, we can't add words even though we're using the system dictionary. This PR puts the `shouldUseHunspell` method back, and uses that for the check.
