### PR TITLE
feat(dict): support hunspell-ko-dict

### DIFF
--- a/src/dictionary-sync.js
+++ b/src/dictionary-sync.js
@@ -98,6 +98,12 @@ export default class DictionarySync {
       }
     }
 
+    //chromium's hunspell-ko dict is available non-uniformed url (https://src.chromium.org/viewvc/chrome?revision=173254&view=revision)
+    //let spellchecker plays with correct langCode but only asks to form url to align with it
+    if (lang.toLowerCase() === 'ko-kr') {
+      lang = 'ko';
+    }
+
     let url = getURLForHunspellDictionary(lang);
     d(`Actually downloading ${url}`);
     await downloadFileOrUrl(url, target);


### PR DESCRIPTION
This PR updates to support `hunspell-ko-dict`, while choromium has upstream support for ko dict(https://src.chromium.org/viewvc/chrome?revision=173254&view=revision), it's url is non-uniformed to other bdict, while other's are formed as `${lang}_${locale}`, ko dict are formed as `${lang}` only. (https://src.chromium.org/viewvc/chrome/trunk/deps/third_party/hunspell_dictionaries/ko-3-0.bdic?sortdir=down&view=log) 

This PR does monkey patching to generate url to download, let other logics for spellchecker works based on correct locale form but only download url can be updated. There might be better placed to handle this (i.e inside of `getUrlForHunspellDict` maybe?), creating PR for reviewing first. Feel freely close / update as necessary. 

