### PR TITLE
Handle native module load failure

### DIFF
--- a/src/spell-check-handler.js
+++ b/src/spell-check-handler.js
@@ -35,7 +35,7 @@ import DictionarySync from './dictionary-sync';
 import {normalizeLanguageCode} from './utility';
 import FakeLocalStorage from './fake-local-storage';
 
-import {Spellchecker} from './node-spellchecker';
+let Spellchecker;
 
 let d = require('debug')('electron-spellchecker:spell-check-handler');
 
@@ -118,6 +118,9 @@ export default class SpellCheckHandler {
    *                                          testing.
    */
   constructor(dictionarySync=null, localStorage=null, scheduler=null) {
+    // NB: Require here so that consumers can handle native module exceptions.
+    Spellchecker = require('./node-spellchecker').Spellchecker;
+
     this.dictionarySync = dictionarySync || new DictionarySync();
     this.switchToLanguage = new Subject();
     this.currentSpellchecker = null;


### PR DESCRIPTION
This is an undesirable workaround for native modules being loaded multiple times in the same process. Consumers can wrap the `SpellCheckHandler` constructor in a try-catch.