### PR TITLE
Correctly parse BCP47

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@paulcbetts/cld": "^2.4.6",
     "@paulcbetts/spellchecker": "^4.0.5",
+    "bcp47": "^1.1.2",
     "debug": "^2.5.1",
     "electron-remote": "^1.1.1",
     "keyboard-layout": "^2.0.7",

--- a/src/cld2.js
+++ b/src/cld2.js
@@ -1,7 +1,6 @@
 const cld = require('@paulcbetts/cld');
 
 export function detect(text) {
-
   return new Promise((res,rej) => {
     cld.detect(text, (err, result) => {
       if (err) { rej(new Error(err.message)); return; }

--- a/src/utility.js
+++ b/src/utility.js
@@ -1,3 +1,4 @@
+import { parse } from 'bcp47';
 
 /**
  * Normalizes language codes by case and separator. Unfortunately, different
@@ -9,14 +10,12 @@
  * @return {String}             The language code in Chromium format.
  */
 export function normalizeLanguageCode(langCode) {
-  let [lang, locale] = langCode.split(/[-_]/);
-  lang = lang.toLowerCase();    locale = locale.toUpperCase();
-
-  if (!lang.match(/^[a-z]{2}$/) || !locale.match(/^[A-Z]{2}$/)) {
+  let result = parse(langCode);
+  if (!result || !result.langtag.language || !result.langtag.region) {
     throw new Error(`${langCode} is not a valid language code`);
   }
 
-  return `${lang}-${locale}`;
+  return `${result.langtag.language.language.toLowerCase()}-${result.langtag.region.toUpperCase()}`;
 }
 
 /**

--- a/src/utility.js
+++ b/src/utility.js
@@ -10,7 +10,7 @@ import { parse } from 'bcp47';
  * @return {String}             The language code in Chromium format.
  */
 export function normalizeLanguageCode(langCode) {
-  let result = parse(langCode);
+  let result = parse(langCode.replace(/[_-]/g, '-'));
   if (!result || !result.langtag.language || !result.langtag.region) {
     throw new Error(`${langCode} is not a valid language code`);
   }


### PR DESCRIPTION
Several languages such as `Sr-latn-CS` would basically throw us into a tailspin because we were assuming all language codes were `ab-XY`. Just use a library to parse these instead.