### PR TITLE
Fix all the bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@paulcbetts/cld": "^2.4.6",
     "@paulcbetts/spellchecker": "^4.0.5",
     "bcp47": "^1.1.2",
-    "debug": "^2.5.1",
+    "debug": "^2.6.3",
     "electron-remote": "^1.1.1",
     "keyboard-layout": "^2.0.7",
     "lru-cache": "^4.0.2",

--- a/src/spell-check-handler.js
+++ b/src/spell-check-handler.js
@@ -401,7 +401,7 @@ export default class SpellCheckHandler {
    */
   async loadDictionaryForLanguageWithAlternatives(langCode, cacheOnly=false) {
     this.fallbackLocaleTable = this.fallbackLocaleTable || require('./fallback-locales');
-    let lang = langCode.substring(0, 2);
+    let lang = langCode.split(/[-_]/)[0];
 
     let alternatives = [langCode, await this.getLikelyLocaleForLanguage(lang), this.fallbackLocaleTable[lang]];
     if (langCode in alternatesTable) {
@@ -593,7 +593,7 @@ export default class SpellCheckHandler {
     // Some distros like Ubuntu make locale -a useless by dumping
     // every possible locale for the language into the list :-/
     let counts = localeList.reduce((acc,x) => {
-      let k = x.substring(0,2);
+      let k = x.split(/[-_\.]/)[0];
       acc[k] = acc[k] || [];
       acc[k].push(x);
 
@@ -616,7 +616,7 @@ export default class SpellCheckHandler {
       let m = process.env.LANG.match(validLangCodeWindowsLinux);
       if (!m) return ret;
 
-      ret[m[0].substring(0, 2)] = normalizeLanguageCode(m[0]);
+      ret[m[0].split(/[-_\.]/)[0]] = normalizeLanguageCode(m[0]);
     }
 
     d(`Result: ${JSON.stringify(ret)}`);

--- a/src/spell-check-handler.js
+++ b/src/spell-check-handler.js
@@ -366,6 +366,8 @@ export default class SpellCheckHandler {
     let dict = null;
     if (isMac) return;
 
+    this.isMisspelledCache.reset();
+
     try {
       const {dictionary, language} = await this.loadDictionaryForLanguageWithAlternatives(langCode);
       actualLang = language; dict = dictionary;

--- a/src/spell-check-handler.js
+++ b/src/spell-check-handler.js
@@ -128,10 +128,7 @@ export default class SpellCheckHandler {
     this.currentSpellcheckerChanged = new Subject();
     this.spellCheckInvoked = new Subject();
     this.spellingErrorOccurred = new Subject();
-    this.isMisspelledCache = new LRU({
-      max: 512,
-      maxAge: 8 * 1000
-    });
+    this.isMisspelledCache = new LRU({ max: 512 });
 
     this.scheduler = scheduler;
     this.shouldAutoCorrect = true;
@@ -459,7 +456,7 @@ export default class SpellCheckHandler {
    */
   isMisspelled(text) {
     let result = this.isMisspelledCache.get(text);
-    if (result !== undefined) {
+    if (result !== undefined && !isMac) {
       return result;
     }
 
@@ -492,7 +489,7 @@ export default class SpellCheckHandler {
       return this.currentSpellchecker.isMisspelled(text.toLocaleLowerCase());
     })();
 
-    this.isMisspelledCache.set(text, result);
+    if (!isMac) this.isMisspelledCache.set(text, result);
     return result;
   }
 


### PR DESCRIPTION
This PR fixes a few separate issues that were trolling people:

* If LocalStorage gets Weird, we would get wedged in a situation where we'd constantly pick the wrong thing over and over. Instead make it just an in-memory cache.
* The LRU cache in front of the real spellchecker defeats automatic language detection, since the result will be different based on the language. Remove it entirely on macOS and make sure to reset it elsewhere
* More fixes related to #55 