### PR TITLE
Patch typing lag on macOS

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
 runtime = electron
-target = 1.4.1
+target = 1.6.4
 target_arch = x64
 disturl = https://atom.io/download/atom-shell

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "cross-env": "^3.1.3",
     "electron-debug": "^1.1.0",
     "electron-mocha": "^3.3.0",
-    "electron-prebuilt-compile": "1.4.12",
+    "electron-prebuilt-compile": "1.6.4",
     "esdoc": "^0.4.8",
     "esdoc-es7-plugin": "0.0.3",
     "esdoc-plugin-async-to-sync": "^0.5.0",

--- a/src/spell-check-handler.js
+++ b/src/spell-check-handler.js
@@ -129,8 +129,7 @@ export default class SpellCheckHandler {
     this.spellCheckInvoked = new Subject();
     this.spellingErrorOccurred = new Subject();
     this.isMisspelledCache = new LRU({
-      max: 512,
-      maxAge: 8 * 1000
+      max: 512, maxAge: 4 * 1000
     });
 
     this.scheduler = scheduler;

--- a/src/spell-check-handler.js
+++ b/src/spell-check-handler.js
@@ -128,7 +128,10 @@ export default class SpellCheckHandler {
     this.currentSpellcheckerChanged = new Subject();
     this.spellCheckInvoked = new Subject();
     this.spellingErrorOccurred = new Subject();
-    this.isMisspelledCache = new LRU({ max: 512 });
+    this.isMisspelledCache = new LRU({
+      max: 512,
+      maxAge: 8 * 1000
+    });
 
     this.scheduler = scheduler;
     this.shouldAutoCorrect = true;
@@ -456,7 +459,7 @@ export default class SpellCheckHandler {
    */
   isMisspelled(text) {
     let result = this.isMisspelledCache.get(text);
-    if (result !== undefined && !isMac) {
+    if (result !== undefined) {
       return result;
     }
 
@@ -489,7 +492,7 @@ export default class SpellCheckHandler {
       return this.currentSpellchecker.isMisspelled(text.toLocaleLowerCase());
     })();
 
-    if (!isMac) this.isMisspelledCache.set(text, result);
+    this.isMisspelledCache.set(text, result);
     return result;
   }
 


### PR DESCRIPTION
In Chrome 56, spellchecker apparently will check far further behind than it used to, it will now recheck the last 8-10 words, whereas previously it would only check the previous word. Put the LRU cache back we got rid of, but make the time lower so it's less likely to interfere with NSSpellchecker