### PR TITLE
Download with fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@paulcbetts/spellchecker": "^4.0.5",
     "bcp47": "^1.1.2",
     "debug": "^2.6.3",
+    "electron-fetch": "^1.0.0",
     "electron-remote": "^1.1.1",
     "keyboard-layout": "^2.0.7",
     "lru-cache": "^4.0.2",

--- a/src/dictionary-sync.js
+++ b/src/dictionary-sync.js
@@ -11,6 +11,7 @@ import 'rxjs/add/operator/toPromise';
 
 import {fs} from './promisify';
 import {normalizeLanguageCode} from './utility';
+import {downloadURL} from './download-url';
 
 let getURLForHunspellDictionary;
 let d = require('debug')('electron-spellchecker:dictionary-sync');
@@ -18,9 +19,6 @@ let d = require('debug')('electron-spellchecker:dictionary-sync');
 const app = process.type === 'renderer' ?
   require('electron').remote.app :
   require('electron').app;
-
-const {downloadFileOrUrl} =
-  require('electron-remote').requireTaskPool(require.resolve('electron-remote/remote-ajax'));
 
 /**
  * DictioanrySync handles downloading and saving Hunspell dictionaries. Pass it
@@ -102,7 +100,7 @@ export default class DictionarySync {
 
     let url = getURLForHunspellDictionary(lang);
     d(`Actually downloading ${url}`);
-    await downloadFileOrUrl(url, target);
+    await downloadURL(url, target);
 
     if (cacheOnly) return target;
 

--- a/src/download-url.js
+++ b/src/download-url.js
@@ -1,0 +1,67 @@
+import {fs} from './promisify';
+
+const fetch = process.type === 'renderer' ?
+  window.fetch :
+  require('electron-fetch').default;
+
+/**
+ * Streams the contents of a URL to a file in the renderer process.
+ * This method uses fetch.
+ *
+ * @param {String} sourceUrl                    The URL to download from
+ * @param {String} targetFile                   The destination file path
+ * @param {ProgressCallback} [progressCallback] A callback invoked when a chunk is received
+ * @param {Number} [length]                     Use to specify the length of the file, otherwise
+ *                                              it'll be read from the Content-Length header
+ * @returns {Promise}                           A Promise indicating completion
+ */
+export async function downloadURL(sourceUrl, targetFile, progressCallback, length) {
+  const request = new Request(sourceUrl, {
+    headers: new Headers({ 'Content-Type': 'application/octet-stream' })
+  });
+
+  const response = await fetch(request);
+  if (!response.ok) throw new Error(`Unable to download, server returned ${response.status} ${response.statusText}`);
+
+  const body = response.body;
+  if (!body) throw new Error('No response body');
+
+  const reader = body.getReader();
+  const writer = fs.createWriteStream(targetFile);
+  const finalLength = length || parseInt(response.headers.get('Content-Length') || '0', 10);
+
+  await streamWithProgress(reader, writer, finalLength, progressCallback);
+
+  writer.end();
+}
+
+/**
+ * Reads chunks from an input stream and pipes them to an output stream.
+ * Optional support for progress callbacks.
+ *
+ * @param {ReadableStreamReader} reader         The input stream to read from
+ * @param {NodeJS.WritableStream} writer        The output stream to write to
+ * @param {String} length                       The length of the content
+ * @param {ProgressCallback} [progressCallback] A callback invoked when a chunk is received
+ */
+async function streamWithProgress(reader, writer, length, progressCallback) {
+  let bytesDone = 0;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const chunk = await reader.read();
+
+    if (chunk.done) {
+      if (progressCallback) progressCallback(length, 100);
+      return;
+    }
+
+    writer.write(Buffer.from(chunk.value));
+
+    if (progressCallback) {
+      bytesDone += chunk.byteLength;
+      const percent = length === 0 ? null : Math.floor(bytesDone / length * 100);
+      progressCallback(bytesDone, percent);
+    }
+  }
+}

--- a/test/dictionary-sync.js
+++ b/test/dictionary-sync.js
@@ -11,13 +11,14 @@ const d = require('debug')('electron-spellchecker-test:dictionary-sync');
 let testCount = 0;
 
 describe('The Dictionary Sync class', function() {
+  if (process.platform === 'darwin') return;
+
   beforeEach(function() {
     this.tempCacheDir = path.join(__dirname, `__dict_sync_${testCount++}`);
     this.fixture = new DictionarySync(this.tempCacheDir);
   });
 
   afterEach(function() {
-    //console.log(this.tempCacheDir);
     rimraf.sync(this.tempCacheDir);
   });
 


### PR DESCRIPTION
In a similar vein as https://github.com/electron-userland/electron-spellchecker/pull/75, this PR attempts to download dictionaries using `fetch` (or [`electron-fetch`](https://github.com/arantes555/electron-fetch) in the main process) rather than the taskpool.