### PR TITLE
Remove rimraf from promisify.js as it is not used

### DIFF
--- a/src/promisify.js
+++ b/src/promisify.js
@@ -1,6 +1,6 @@
 import pify from 'pify';
 
-module.exports = ['fs', 'mkdirp', 'rimraf'].reduce((acc, x) => {
+module.exports = ['fs', 'mkdirp'].reduce((acc, x) => {
   acc[x] = pify(require(x));
   return acc;
 }, {});


### PR DESCRIPTION
Rimraf is included for testing purposes in devDependencies, however due to its existence in promisify file, it fails when distributed without the rimraf.