### PR TITLE
Expose spellchecker

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,10 @@ import ContextMenuBuilder from './context-menu-builder';
 import ContextMenuListener from './context-menu-listener';
 import DictionarySync from './dictionary-sync';
 import SpellCheckHandler from './spell-check-handler';
+import SpellChecker from './node-spellchecker';
 
 /**
- * Overrides the default logging function (the `debug` library) with another 
+ * Overrides the default logging function (the `debug` library) with another
  * logger.
  *
  * @param {Function}  fn    The `console.log` like function that will write debug
@@ -21,5 +22,6 @@ module.exports = {
   ContextMenuListener,
   DictionarySync,
   SpellCheckHandler,
-  setGlobalLogger
+  SpellChecker,
+  setGlobalLogger,
 };


### PR DESCRIPTION
This allows users to get to the underlying spellchecker (and its utility functions) directly.