### PR TITLE
Use copyImageAt instead of convertImageToBase64

### DIFF
--- a/src/context-menu-builder.js
+++ b/src/context-menu-builder.js
@@ -320,10 +320,10 @@ export default class ContextMenuBuilder {
    * Adds "Copy Image" and "Copy Image URL" items when `src` is valid.
    */
   addImageItems(menu, menuInfo) {
+    let target = this.getWebContents();
     let copyImage = new MenuItem({
       label: this.stringTable.copyImage(),
-      click: () => this.convertImageToBase64(menuInfo.srcURL,
-        (dataURL) => clipboard.writeImage(nativeImage.createFromDataURL(dataURL)))
+      click: () => target.copyImageAt(menuInfo.x, menuInfo.y)
     });
 
     menu.append(copyImage);
@@ -405,31 +405,5 @@ export default class ContextMenuBuilder {
 
     menu.append(inspect);
     return menu;
-  }
-
-  /**
-   * Converts an image to a base-64 encoded string.
-   *
-   * @param  {String} url           The image URL
-   * @param  {Function} callback    A callback that will be invoked with the result
-   * @param  {String} outputFormat  The image format to use, defaults to 'image/png'
-   */
-  convertImageToBase64(url, callback, outputFormat='image/png') {
-    let canvas = document.createElement('CANVAS');
-    let ctx = canvas.getContext('2d');
-    let img = new Image();
-    img.crossOrigin = 'Anonymous';
-
-    img.onload = () => {
-      canvas.height = img.height;
-      canvas.width = img.width;
-      ctx.drawImage(img, 0, 0);
-
-      let dataURL = canvas.toDataURL(outputFormat);
-      canvas = null;
-      callback(dataURL);
-    };
-
-    img.src = url;
   }
 }


### PR DESCRIPTION
This replaces convertImageToBase64 with copyImageAt. This means that copying image works offline as well as when there might be CORS errors.