### PR TITLE
Use correct rx `merge` import

### DIFF
--- a/src/spell-check-handler.js
+++ b/src/spell-check-handler.js
@@ -12,6 +12,7 @@ import 'rxjs/add/observable/empty';
 import 'rxjs/add/observable/fromEvent';
 import 'rxjs/add/observable/fromPromise';
 import 'rxjs/add/observable/of';
+import 'rxjs/add/observable/merge';
 
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/concat';
@@ -19,7 +20,6 @@ import 'rxjs/add/operator/concatMap';
 import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/mergeMap';
-import 'rxjs/add/operator/merge';
 import 'rxjs/add/operator/observeOn';
 import 'rxjs/add/operator/reduce';
 import 'rxjs/add/operator/startWith';


### PR DESCRIPTION
It looks like the incorrect rxjs import for `merge` is being used. When using this on Windows, I get a `Cannot call merge of undefined` (or something like that) here https://github.com/ccnokes/electron-spellchecker/blob/6181e409cd62ab1029b54aeceb2ae9375bc27232/src/spell-check-handler.js#L245.

The issue is  `import 'rxjs/add/operator/merge'` adds `merge` to the prototype, like `Observable_1.Observable.prototype.merge = merge_1.merge;` whereas `import 'rxjs/add/observable/merge';` adds it as a static method (which is how it's being used), like `Observable_1.Observable.merge = merge_1.merge;` 

It only occurs on Windows (maybe Linux too, didn't test it though) because `attachToInput` bails out early on mac (see https://github.com/ccnokes/electron-spellchecker/blob/6181e409cd62ab1029b54aeceb2ae9375bc27232/src/spell-check-handler.js#L211).

I'm not sure how someone else didn't see this by now.... maybe I'm doing something wrong? But this fixes it for me on Windows. 