### PR TITLE
Fix buildLikelyLocaleTable to not rely on Observable#catch

### DIFF
--- a/src/spell-check-handler.js
+++ b/src/spell-check-handler.js
@@ -588,9 +588,9 @@ export default class SpellCheckHandler {
 
     if (process.platform === 'linux') {
       let locales = await spawn('locale', ['-a'])
-        .catch(() => Observable.of(null))
         .reduce((acc,x) => { acc.push(...x.split('\n')); return acc; }, [])
-        .toPromise();
+        .toPromise()
+        .catch(() => []);
 
       d(`Raw Locale list: ${JSON.stringify(locales)}`);
 


### PR DESCRIPTION
If spawn-rx uses a different version/instance of rxjs than electron-spellchecker, there is no `#catch()` method on the Observable, causing this call to fail.

Additionally, if the spawn did ever fail and the catch block worked, the call would fail in the `reduce` step with `TypeError: Cannot read property 'split' of null`.

This fixes these issues.

Fixes #110.

Side note: I don't see any CI system being used, and running the tests don't work out of the box (needs to be passed through babel first), which makes contributing difficult. I'm happy to submit a PR for e.g. testing on Travis if there's interest.
