### PR TITLE
chore: update node-spellchecker dep for electron 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/paulcbetts/electron-spellchecker",
   "dependencies": {
     "@paulcbetts/cld": "^2.4.6",
-    "@paulcbetts/spellchecker": "^4.0.6",
+    "@nornagon/spellchecker": "^4.0.7",
     "bcp47": "^1.1.2",
     "debug": "^2.6.3",
     "electron-remote": "^1.1.1",


### PR DESCRIPTION
this was causing compile errors due to `v8::Handle` being deprecated & removed.