### PR TITLE
Let the menu popup default to showing on the currently focused BrowserWindow

### DIFF
--- a/src/context-menu-builder.js
+++ b/src/context-menu-builder.js
@@ -96,7 +96,7 @@ export default class ContextMenuBuilder {
   async showPopupMenu(contextInfo) {
     let menu = await this.buildMenuForElement(contextInfo);
     if (!menu) return;
-    menu.popup(remote.getCurrentWindow(), { async: true });
+    menu.popup();
   }
 
   /**


### PR DESCRIPTION
It looks like ```menu.popup()``` defaults to the currently focused BrowserWindow [now](https://electronjs.org/docs/api/menu#menupopupoptions), so there is no need to specify it with remote.getCurrentWindow(). This change also workarounds an [issue](https://github.com/electron/electron/issues/16558) where ```remote.getCurrentWindow()``` may return null in some environments, resulting in a popup to not appear as expected.