### PR TITLE
Increase LRU cache size to prevent thrashing, invalidate on "learn word"

### DIFF
--- a/src/spell-check-handler.js
+++ b/src/spell-check-handler.js
@@ -387,7 +387,6 @@ module.exports = class SpellCheckHandler {
     let actualLang;
     let dict = null;
 
-    // Set language on Linux & Windows (Hunspell)
     this.isMisspelledCache.reset();
     
     // Set language on macOS
@@ -397,6 +396,7 @@ module.exports = class SpellCheckHandler {
       return this.currentSpellchecker.setDictionary(langCode);
     }
 
+    // Set language on Linux & Windows (Hunspell)
     try {
       const {dictionary, language} = await this.loadDictionaryForLanguageWithAlternatives(langCode);
       actualLang = language; dict = dictionary;

--- a/src/spell-check-handler.js
+++ b/src/spell-check-handler.js
@@ -127,9 +127,7 @@ module.exports = class SpellCheckHandler {
     this.currentSpellcheckerChanged = new Subject();
     this.spellCheckInvoked = new Subject();
     this.spellingErrorOccurred = new Subject();
-    this.isMisspelledCache = new LRU({
-      max: 512, maxAge: 4 * 1000
-    });
+    this.isMisspelledCache = new LRU({ max: 5000 });
 
     this.scheduler = scheduler;
     this.shouldAutoCorrect = true;
@@ -389,15 +387,15 @@ module.exports = class SpellCheckHandler {
     let actualLang;
     let dict = null;
 
+    // Set language on Linux & Windows (Hunspell)
+    this.isMisspelledCache.reset();
+    
     // Set language on macOS
     if (isMac && this.currentSpellchecker) {
       d(`Setting current spellchecker to ${langCode}`);
       this.currentSpellcheckerLanguage = langCode;
       return this.currentSpellchecker.setDictionary(langCode);
     }
-
-    // Set language on Linux & Windows (Hunspell)
-    this.isMisspelledCache.reset();
 
     try {
       const {dictionary, language} = await this.loadDictionaryForLanguageWithAlternatives(langCode);
@@ -575,6 +573,7 @@ module.exports = class SpellCheckHandler {
     if (!isMac) return;
     if (!this.currentSpellchecker) return;
 
+    this.isMisspelledCache.reset();
     this.currentSpellchecker.add(text);
   }
 


### PR DESCRIPTION
Fixes #136

I'm not sure what the motivation for the 4s invalidation time in the LRU cache was. My best guess is that it was necessary to make the "learn spelling" feature work, so instead of re-querying every 4 seconds I made `addToDictionary` reset the cache. I also made sure the cache is reset when you switch languages on macOS (this may have actually been a bug?)