### PR TITLE
 Add support for Electron 5 and above

### DIFF
--- a/src/spell-check-handler.js
+++ b/src/spell-check-handler.js
@@ -465,14 +465,10 @@ module.exports = class SpellCheckHandler {
    */
   setSpellCheckProvider(webFrame) {
     if (process.versions.electron >= '5.0.0') {
-      d('DEBUG: Setting provider for Electron 5');
-      // Electron 5 and above:
       webFrame.setSpellCheckProvider(
         this.currentSpellcheckerLanguage,
         { spellCheck: this.handleElectronSpellCheck.bind(this) });
     } else {
-      d('DEBUG: Setting provider for Electron 4');
-      // Electron 4 and below:
       webFrame.setSpellCheckProvider(
         this.currentSpellcheckerLanguage,
         this.shouldAutoCorrect,

--- a/src/spell-check-handler.js
+++ b/src/spell-check-handler.js
@@ -252,9 +252,9 @@ module.exports = class SpellCheckHandler {
     }
 
     let contentToCheck = Observable.merge(
-      this.spellingErrorOccurred,
-      initialInputText,
-      possiblySwitchedCharacterSets)
+        this.spellingErrorOccurred,
+        initialInputText,
+        possiblySwitchedCharacterSets)
       .mergeMap(() => {
         if (lastInputText.length < 8) return Observable.empty();
         return Observable.of(lastInputText);
@@ -292,7 +292,7 @@ module.exports = class SpellCheckHandler {
       let prevSpellCheckLanguage;
 
       disp.add(this.currentSpellcheckerChanged
-        .startWith(true)
+          .startWith(true)
         .filter(() => this.currentSpellcheckerLanguage)
         .subscribe(() => {
           if (prevSpellCheckLanguage === this.currentSpellcheckerLanguage) return;
@@ -382,7 +382,7 @@ module.exports = class SpellCheckHandler {
     let dict = null;
 
     this.isMisspelledCache.reset();
-
+    
     // Set language on macOS
     if (isMac && this.currentSpellchecker) {
       d(`Setting current spellchecker to ${langCode}`);
@@ -443,7 +443,7 @@ module.exports = class SpellCheckHandler {
     return await Observable.of(...alternatives)
       .concatMap((l) => {
         return Observable.defer(() =>
-          Observable.fromPromise(this.dictionarySync.loadDictionaryForLanguage(l, cacheOnly)))
+            Observable.fromPromise(this.dictionarySync.loadDictionaryForLanguage(l, cacheOnly)))
           .map((d) => ({language: l, dictionary: d}))
           .do(({language}) => {
             alternatesTable[langCode] = language;

--- a/src/spell-check-handler.js
+++ b/src/spell-check-handler.js
@@ -140,7 +140,6 @@ module.exports = class SpellCheckHandler {
       this.currentSpellchecker = new Spellchecker();
       this.currentSpellcheckerLanguage = 'en-US';
 
-      d('DEBUG: Settings Spell Check Provider...');
       if (webFrame) {
         this.setSpellCheckProvider(webFrame);
       }


### PR DESCRIPTION
Starting with Electron 5.0.0, the function `webFrame.setSpellCheckProvider` has a different signature, in order to support asynchronous spell checkers. For more information on this change in Electron, see electron/electron#14032.

This diff updates `SpellCheckHandler` to use the new interface if running on Electron 5.0.0 and above. However, it still checks the spelling synchronously like before.

If running on Electron versions below 5.0.0, the `SpellCheckHandler` still works.

Closes #144.