### PR TITLE
Fix and greatly simplify the example app

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -1,52 +1,9 @@
 <html>
 <head>
-  <style type="text/less">
-  #container {
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    align-content: stretch;
-    height: 100vh;
-    width: 100vw;
-  }
-  
-  #ta {
-    flex: 1 1 auto;
-  }
-  </style>
 </head>
 <body>
-  <div id="container">
-    <textarea id="ta"></textarea>
-
-    <webview src="https://gist.github.com" style="width: 100%; height: 600px" preload="./preload.js"></webview>>
-
-    <div id="info">
-      <h3>Type some text!</h3>
-      <p id="detectedLang">Unknown language</p>
-      <img height="33%"
-      src="http://pixel.nymag.com/imgs/daily/following/2016/05/12/12376681_1063072477089016_3145722177588178860_n.nocrop.w536.h2147483647.2x.jpg" />
-    </div>
+  <div>
+    <textarea></textarea>
   </div>
-  
-  <script>
-  import SpellCheckHandler from '../src/spell-check-handler';
-  import ContextMenuListener from '../src/context-menu-listener';
-  import ContextMenuBuilder from '../src/context-menu-builder';
-  
-  window.spellCheckHandler = new SpellCheckHandler();
-  window.spellCheckHandler.attachToInput();
-  window.spellCheckHandler.currentSpellcheckerChanged.subscribe(() => {
-    document.getElementById('detectedLang').innerText = `Current language is ${window.spellCheckHandler.currentSpellcheckerLanguage}`;
-  });
-  
-  window.spellCheckHandler.provideHintText('This is probably the language that you want to check in');
-  window.spellCheckHandler.autoUnloadDictionariesOnBlur();
-  
-  let contextMenuBuilder = new ContextMenuBuilder(window.spellCheckHandler);
-  let contextMenuListener = new ContextMenuListener(async (info) => {
-    await contextMenuBuilder.showPopupMenu(info);
-  });
-  </script>
 </body>
 </html>

--- a/example/main.js
+++ b/example/main.js
@@ -1,5 +1,6 @@
 const {app, BrowserWindow } = require('electron');
 const electronDebug = require('electron-debug');
+const path = require('path');
 
 let mainWindow = null;
 electronDebug({enabled: true, showDevTools: true});
@@ -11,7 +12,10 @@ app.on('window-all-closed', () => {
 app.on('ready', () => {
   mainWindow = new BrowserWindow({
     width: 580,
-    height: 365
+    height: 365,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js')
+    }
   });
 
   mainWindow.loadURL(`file://${__dirname}/index.html`);

--- a/example/preload.js
+++ b/example/preload.js
@@ -1,14 +1,20 @@
-window.ItWorked = true;
-
-const SpellCheckHandler = require('../lib/spell-check-handler').default;
-const ContextMenuListener = require('../lib/context-menu-listener').default;
-const ContextMenuBuilder = require('../lib/context-menu-builder').default;
+const SpellCheckHandler = require("../src/spell-check-handler");
+const ContextMenuListener = require("../src/context-menu-listener");
+const ContextMenuBuilder = require("../src/context-menu-builder");
 
 window.spellCheckHandler = new SpellCheckHandler();
-setTimeout(() => window.spellCheckHandler.attachToInput(), 1000);
+window.spellCheckHandler.attachToInput();
 
-window.spellCheckHandler.provideHintText('This is probably the language that you want to check in');
+window.spellCheckHandler.provideHintText(
+  "This is probably the language that you want to check in"
+);
 window.spellCheckHandler.autoUnloadDictionariesOnBlur();
 
-window.contextMenuBuilder = new ContextMenuBuilder(window.spellCheckHandler, null, true);
-window.contextMenuListener = new ContextMenuListener((info) => { window.contextMenuBuilder.showPopupMenu(info); });
+window.contextMenuBuilder = new ContextMenuBuilder(
+  window.spellCheckHandler,
+  null,
+  true
+);
+window.contextMenuListener = new ContextMenuListener(info => {
+  window.contextMenuBuilder.showPopupMenu(info);
+});


### PR DESCRIPTION
Perhaps there's something I'm misunderstanding here, but from what I
tell, the example app in this repo has been abandoned, and doesn't
actually work anymore.  There are synax errors that cause it to fail at
runtime, due to the use of `import` in index.html. Furthermore, there is
a preload.js script that contains the same code that is in the
index.html file, but that preload.js file isn't being specified when
creating the `BrowserWindow` in main.js.

This change fixes these issues, and in doing so, it greatly simplifies
the example app.