### PR TITLE
Fix language detection condition on macOS

### DIFF
--- a/src/spell-check-handler.js
+++ b/src/spell-check-handler.js
@@ -166,7 +166,7 @@ module.exports = class SpellCheckHandler {
     // while calling it with an empty language will set it to `true`
     if (isMac && !!value) {
       this.switchLanguage();
-    } else if (isMac && !!value && this.currentSpellcheckerLanguage) {
+    } else if (isMac && !value && this.currentSpellcheckerLanguage) {
       this.switchLanguage(this.currentSpellcheckerLanguage);
     }
   }


### PR DESCRIPTION
Fixed `automaticallyIdentifyLanguages` method on macOS to disable automatic language detection without calling `switchLanguage` again.

>  // Calling `setDictionary` on the macOS implementation of `@nornagon/spellchecker`
>  // is the only way to set the `automaticallyIdentifyLanguages` property on the
>  // native NSSpellchecker. Calling switchLanguage with a language will set it `false`,
>  // while calling it with an empty language will set it to `true`