### PR TITLE
Avoid dispatching a "changed" event if the language wasn't changed

### DIFF
--- a/src/spell-check-handler.js
+++ b/src/spell-check-handler.js
@@ -401,11 +401,11 @@ module.exports = class SpellCheckHandler {
 
     if (!dict) {
       d(`dictionary for ${langCode}_${actualLang} is not available`);
-			if (this.currentSpellcheckerLanguage !== actualLang) {
-				this.currentSpellcheckerLanguage = actualLang;
-				this.currentSpellchecker = null;
-				this.currentSpellcheckerChanged.next(true);
-			}
+      if (this.currentSpellcheckerLanguage !== actualLang) {
+        this.currentSpellcheckerLanguage = actualLang;
+        this.currentSpellchecker = null;
+        this.currentSpellcheckerChanged.next(true);
+      }
       return;
     }
 

--- a/src/spell-check-handler.js
+++ b/src/spell-check-handler.js
@@ -401,9 +401,11 @@ module.exports = class SpellCheckHandler {
 
     if (!dict) {
       d(`dictionary for ${langCode}_${actualLang} is not available`);
-      this.currentSpellcheckerLanguage = actualLang;
-      this.currentSpellchecker = null;
-      this.currentSpellcheckerChanged.next(true);
+			if (this.currentSpellcheckerLanguage !== actualLang) {
+				this.currentSpellcheckerLanguage = actualLang;
+				this.currentSpellchecker = null;
+				this.currentSpellcheckerChanged.next(true);
+			}
       return;
     }
 


### PR DESCRIPTION
In the case that actualLang == currentSpellcheckerLanguage, there is no need to fire a spellchecker changed event. This is already the behavior in the happy case (see if statement on old line 411). This PR makes that consistent with the !dict error case.